### PR TITLE
Created launcher for RecordCommonStats

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4834,9 +4834,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -11662,13 +11662,13 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -12285,9 +12285,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.3.tgz",
-      "integrity": "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
+      "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -12295,7 +12295,7 @@
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
         "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.14"
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/frontend/src/main/components/Jobs/RecordCommonStatsForm.jsx
+++ b/frontend/src/main/components/Jobs/RecordCommonStatsForm.jsx
@@ -1,0 +1,16 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+
+function RecordCommonStatsForm({ submitAction }) {
+  const { handleSubmit } = useForm();
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      <p>Click this button to record all common stats!</p>
+      <Button type="submit" data-testid="RecordCommonStats-Submit-Button">
+        Generate
+      </Button>
+    </Form>
+  );
+}
+export default RecordCommonStatsForm;

--- a/frontend/src/main/pages/AdminJobsPage.jsx
+++ b/frontend/src/main/pages/AdminJobsPage.jsx
@@ -5,6 +5,7 @@ import Accordion from "react-bootstrap/Accordion";
 import TestJobForm from "main/components/Jobs/TestJobForm";
 import UpdateCowHealthForm from "main/components/Jobs/UpdateCowHealthForm";
 import MilkCowsJobForm from "main/components/Jobs/MilkCowsJobForm";
+import RecordCommonStatsForm from "main/components/Jobs/RecordCommonStatsForm";
 import InstructorReportForm from "main/components/Jobs/InstructorReportForm";
 import InstructorReportSpecificCommonsForm from "main/components/Jobs/InstructorReportSpecificCommonsForm";
 import { toast } from "react-toastify";
@@ -128,6 +129,29 @@ const AdminJobsPage = () => {
       MilkTheCowsSingleMutation.mutate(data);
     }
   };
+
+  // *** RecordCommonStats job ***
+
+  const objectToAxiosParamsRecordCommonStatsJob = () => {
+    return {
+      url: `/api/jobs/launch/recordcommonstats`,
+      method: "POST",
+    };
+  };
+
+  // Stryker disable all
+  const RecordCommonStatsMutation = useBackendMutation(
+    objectToAxiosParamsRecordCommonStatsJob,
+    {},
+    ["/api/jobs/all"],
+  );
+
+  // Stryker restore all
+    const submitRecordCommonStatsJob = async () => {
+    toast("Submitted Job: Record Common Stats");
+    RecordCommonStatsMutation.mutate();
+  };
+
   // *** Instructor Report job ***
 
   const objectToAxiosParamsInstructorReportJob = () => ({
@@ -186,6 +210,10 @@ const AdminJobsPage = () => {
     {
       name: "Milk The Cows",
       form: <MilkCowsJobForm submitAction={submitMilkTheCowsJob} />,
+    },
+        {
+      name: "Record Common Stats",
+      form: <RecordCommonStatsForm submitAction={submitRecordCommonStatsJob} />,
     },
     {
       name: "Instructor Report",


### PR DESCRIPTION
## Overview
In this PR, we added a launcher for the RecordCommonStats endpoint.

## Screenshots
<img width="1706" height="708" alt="image" src="https://github.com/user-attachments/assets/2b364eb3-5ba9-438a-951c-5c5e9729c6a3" />


## Feedback Request
- I'm not sure how to check the results of running this endpoint. The results should be stored in the CommonStats repository.

## Validation
1. Download this branch.
2. Run the project.
3. Go to Admin -> Manage Jobs -> Record Common Stats -> Generate
4. A job should be created and ran successfully

## Tests
<!--Add any additional tests or required tests-->
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
Closes #18 
