### PR TITLE
Ys frontend pagination of chat messages entered in commons

### DIFF
--- a/frontend/src/fixtures/courseFixtures.js
+++ b/frontend/src/fixtures/courseFixtures.js
@@ -1,0 +1,31 @@
+const courseFixtures = {
+  oneCourse: {
+    id: 1,
+    code: "CMPSC 156",
+    name: "Advanced Applications Programming",
+    term: "F25",
+  },
+
+  threeCourses: [
+    {
+      id: 1,
+      code: "CMPSC 156",
+      name: "Advanced Applications Programming",
+      term: "F25",
+    },
+    {
+      id: 2,
+      code: "CHEM 123",
+      name: "Environmental Chemistry",
+      term: "W26",
+    },
+    {
+      id: 3,
+      code: "MATH 8",
+      name: "Transition to Higher Mathematics",
+      term: "F25",
+    },
+  ],
+};
+
+export { courseFixtures };

--- a/frontend/src/main/components/Chat/ChatDisplay.jsx
+++ b/frontend/src/main/components/Chat/ChatDisplay.jsx
@@ -19,6 +19,7 @@ const ChatDisplay = ({ commonsId }) => {
       params: { commonsId, page, size: 10 },
     },
     { content: [], last: true },
+    { refetchInterval: 2000 }
   );
 
   const { data: userCommonsList } = useBackend(

--- a/frontend/src/main/components/Chat/ChatDisplay.jsx
+++ b/frontend/src/main/components/Chat/ChatDisplay.jsx
@@ -19,7 +19,7 @@ const ChatDisplay = ({ commonsId }) => {
       params: { commonsId, page, size: 10 },
     },
     { content: [], last: true },
-    { refetchInterval: 2000 }
+    { refetchInterval: 2000 },
   );
 
   const { data: userCommonsList } = useBackend(

--- a/frontend/src/main/components/Chat/ChatDisplay.jsx
+++ b/frontend/src/main/components/Chat/ChatDisplay.jsx
@@ -4,50 +4,50 @@ import { useBackend } from "main/utils/useBackend";
 
 const ChatDisplay = ({ commonsId }) => {
   const [messages, setMessages] = useState([]);
-
   const [page, setPage] = useState(0);
-
+  // Stryker disable next-line all
   const [isLastPage, setIsLastPage] = useState(false);
 
   const processedMessageIds = useRef(new Set());
 
   // Stryker disable all
   const { data: messagesPage } = useBackend(
-    ["/api/chat/get", page],
+    ["/api/chat/get", commonsId, page],
     {
       method: "GET",
       url: "/api/chat/get",
-      params: {
-        commonsId: commonsId,
-        page: page,
-        size: 10,
-      },
+      params: { commonsId, page, size: 10 },
     },
-    { content: [], last: true },
+    { content: [], last: true }
   );
 
   const { data: userCommonsList } = useBackend(
-    ["/api/usercommons/commons/all", commonsId],
+    ["/api/usercommons/all", commonsId],
     {
       method: "GET",
-      url: "/api/usercommons/commons/all",
+      url: "/api/usercommons/all",
       params: { commonsId },
     },
-    [],
+    []
   );
 
   useEffect(() => {
-    // if (!messagesPage || !messagesPage.content) return;
+    setPage(0);
+    setMessages([]);
+    processedMessageIds.current = new Set();
+    setIsLastPage(false);
+  }, [commonsId]);
+
+  useEffect(() => {
 
     const newMessages = messagesPage.content.filter((msg) => {
-      if (processedMessageIds.current.has(msg.id)) return false;
+      const isNew = !processedMessageIds.current.has(msg.id);
       processedMessageIds.current.add(msg.id);
-      return true;
+      return isNew;
     });
 
-    if (newMessages.length === 0) return;
-
     setMessages((old) => [...old, ...newMessages]);
+
     setIsLastPage(messagesPage.last);
   }, [messagesPage]);
 
@@ -69,12 +69,12 @@ const ChatDisplay = ({ commonsId }) => {
         maxHeight: "300px",
       }}
     >
-      {sortedMessages.map((message) => (
+      {sortedMessages.map((m) => (
         <ChatMessageDisplay
-          key={message.id}
+          key={m.id}
           message={{
-            ...message,
-            username: userIdToUsername[message.userId],
+            ...m,
+            username: userIdToUsername[m.userId],
           }}
         />
       ))}
@@ -82,7 +82,7 @@ const ChatDisplay = ({ commonsId }) => {
       {!isLastPage ? (
         <button
           data-testid="MoreMessagesButton"
-          onClick={() => setPage(page + 1)}
+          onClick={() => setPage((p) => p + 1)}
         >
           More messages
         </button>

--- a/frontend/src/main/components/Chat/ChatDisplay.jsx
+++ b/frontend/src/main/components/Chat/ChatDisplay.jsx
@@ -18,7 +18,7 @@ const ChatDisplay = ({ commonsId }) => {
       url: "/api/chat/get",
       params: { commonsId, page, size: 10 },
     },
-    { content: [], last: true }
+    { content: [], last: true },
   );
 
   const { data: userCommonsList } = useBackend(
@@ -28,7 +28,7 @@ const ChatDisplay = ({ commonsId }) => {
       url: "/api/usercommons/all",
       params: { commonsId },
     },
-    []
+    [],
   );
 
   useEffect(() => {
@@ -39,7 +39,6 @@ const ChatDisplay = ({ commonsId }) => {
   }, [commonsId]);
 
   useEffect(() => {
-
     const newMessages = messagesPage.content.filter((msg) => {
       const isNew = !processedMessageIds.current.has(msg.id);
       processedMessageIds.current.add(msg.id);

--- a/frontend/src/main/components/Chat/ChatDisplay.jsx
+++ b/frontend/src/main/components/Chat/ChatDisplay.jsx
@@ -22,10 +22,10 @@ const ChatDisplay = ({ commonsId }) => {
   );
 
   const { data: userCommonsList } = useBackend(
-    ["/api/usercommons/all", commonsId],
+    ["/api/usercommons/commons/all", commonsId],
     {
       method: "GET",
-      url: "/api/usercommons/all",
+      url: "/api/usercommons/commons/all",
       params: { commonsId },
     },
     [],

--- a/frontend/src/main/components/Courses/CourseTable.jsx
+++ b/frontend/src/main/components/Courses/CourseTable.jsx
@@ -1,0 +1,60 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/courseUtils";
+import { useNavigate } from "react-router";
+import { hasRole } from "main/utils/currentUser";
+
+export default function CourseTable({ courses, currentUser }) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/course/edit/${cell.row.original.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/course/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      Header: "id",
+      accessor: "id", // accessor is the "key" in the data
+    },
+    {
+      Header: "Code",
+      accessor: "code",
+    },
+    {
+      Header: "Name",
+      accessor: "name",
+    },
+    {
+      Header: "Term",
+      accessor: "term",
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, "CourseTable"));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, "CourseTable"),
+    );
+  }
+
+  return <OurTable data={courses} columns={columns} testid={"CourseTable"} />;
+}

--- a/frontend/src/main/utils/courseUtils.js
+++ b/frontend/src/main/utils/courseUtils.js
@@ -10,7 +10,7 @@ export function cellToAxiosParamsDelete(cell) {
     url: "/api/course",
     method: "DELETE",
     params: {
-      id: cell.row.original.id,
+      id: cell.row.values.id,
     },
   };
 }

--- a/frontend/src/main/utils/courseUtils.js
+++ b/frontend/src/main/utils/courseUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/course",
+    method: "DELETE",
+    params: {
+      id: cell.row.original.id,
+    },
+  };
+}

--- a/frontend/src/stories/components/Chat/ChatDisplay.stories.jsx
+++ b/frontend/src/stories/components/Chat/ChatDisplay.stories.jsx
@@ -22,12 +22,11 @@ Empty.args = {
 
 Empty.parameters = {
   msw: [
-    http.get("/api/chat/get?page=0&size=10&commonsId=1", () => {
-      return HttpResponse.json({ content: [] }, { status: 200 });
+    http.get(/\/api\/chat\/get.*/, ({ request: _request }) => {
+      return HttpResponse.json({ content: [], last: true });
     }),
-
-    http.get("/api/usercommons/all?commonsId=1", () => {
-      return HttpResponse.json([], { status: 200 });
+    http.get(/\/api\/usercommons\/commons\/all.*/, () => {
+      return HttpResponse.json([]);
     }),
   ],
 };
@@ -40,20 +39,18 @@ OneMessage.args = {
 
 OneMessage.parameters = {
   msw: [
-    http.get("/api/chat/get?page=0&size=10&commonsId=1", () => {
+    http.get(/\/api\/chat\/get.*/, ({ request: _request }) => {
       return HttpResponse.json(
         {
           content: chatMessageFixtures.oneChatMessage,
-          totalPages: 1,
+          last: true,
         },
         { status: 200 },
       );
     }),
 
-    http.get("/api/usercommons/all?commonsId=1", () => {
-      return HttpResponse.json(userCommonsFixtures.oneUserCommons, {
-        status: 200,
-      });
+    http.get(/\/api\/usercommons\/commons\/all.*/, () => {
+      return HttpResponse.json(userCommonsFixtures.oneUserCommons);
     }),
   ],
 };
@@ -66,46 +63,46 @@ ThreeMessages.args = {
 
 ThreeMessages.parameters = {
   msw: [
-    http.get("/api/chat/get?page=0&size=10&commonsId=1", () => {
+    http.get(/\/api\/chat\/get.*/, ({ request: _request }) => {
       return HttpResponse.json(
         {
           content: chatMessageFixtures.threeChatMessages,
-          totalPages: 1,
+          last: true,
         },
         { status: 200 },
       );
     }),
 
-    http.get("/api/usercommons/all?commonsId=1", () => {
-      return HttpResponse.json(userCommonsFixtures.threeUserCommons, {
-        status: 200,
-      });
+    http.get(/\/api\/usercommons\/commons\/all.*/, () => {
+      return HttpResponse.json(userCommonsFixtures.threeUserCommons);
     }),
   ],
 };
 
-export const TwelveMessages = Template.bind({});
+// export const TwelveMessages = Template.bind({});
 
-TwelveMessages.args = {
-  commonsId: 1,
-};
+// TwelveMessages.args = {
+//   commonsId: 1,
+// };
 
-TwelveMessages.parameters = {
-  msw: [
-    http.get("/api/chat/get?page=0&size=10&commonsId=1", () => {
-      return HttpResponse.json(
-        {
-          content: chatMessageFixtures.twelveChatMessages,
-          totalPages: 2,
-        },
-        { status: 200 },
-      );
-    }),
+// TwelveMessages.parameters = {
+//   msw: [
+//     http.get(/\/api\/chat\/get.*/, ({ request: _request }) => {
+//       const url = new URL(_request.url);
+//       const page = Number(url.searchParams.get("page")) || 0;
+//       const size = Number(url.searchParams.get("size")) || 10;
 
-    http.get("/api/usercommons/all?commonsId=1", () => {
-      return HttpResponse.json(userCommonsFixtures.tenUserCommons, {
-        status: 200,
-      });
-    }),
-  ],
-};
+//       const start = page * size;
+//       const end = start + size;
+
+//       const messages = chatMessageFixtures.twelveChatMessages.slice(start, end);
+//       const last = end >= chatMessageFixtures.twelveChatMessages.length;
+
+//       return HttpResponse.json({ content: messages, last });
+//     }),
+
+//     http.get(/\/api\/usercommons\/commons\/all.*/, () => {
+//       return HttpResponse.json(userCommonsFixtures.tenUserCommons);
+//     }),
+//   ],
+// };

--- a/frontend/src/stories/components/Chat/ChatDisplay.stories.jsx
+++ b/frontend/src/stories/components/Chat/ChatDisplay.stories.jsx
@@ -4,105 +4,162 @@ import { http, HttpResponse } from "msw";
 import ChatDisplay from "main/components/Chat/ChatDisplay";
 import { chatMessageFixtures } from "fixtures/chatMessageFixtures";
 import userCommonsFixtures from "fixtures/userCommonsFixtures";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 
 export default {
   title: "components/Chat/ChatDisplay",
   component: ChatDisplay,
 };
 
-const Template = (args) => {
-  return <ChatDisplay {...args} />;
-};
+const Template = (args) => <ChatDisplay {...args} />;
 
 export const Empty = Template.bind({});
-
-Empty.args = {
-  commonsId: 1,
-};
+Empty.args = { commonsId: 101 };
 
 Empty.parameters = {
-  msw: [
-    http.get(/\/api\/chat\/get.*/, ({ request: _request }) => {
-      return HttpResponse.json({ content: [], last: true });
-    }),
-    http.get(/\/api\/usercommons\/commons\/all.*/, () => {
-      return HttpResponse.json([]);
-    }),
-  ],
+  msw: {
+    handlers: [
+      http.get("/api/currentUser", () =>
+        HttpResponse.json(apiCurrentUserFixtures.adminUser)
+      ),
+
+      http.get("/api/chat/get", ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get("commonsId") === "101") {
+          return HttpResponse.json({ content: [], last: true });
+        }
+        return HttpResponse.json({ content: [], last: true });
+      }),
+
+      http.get("/api/usercommons/all", ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get("commonsId") === "101") {
+          return HttpResponse.json([], { status: 200 });
+        }
+        return HttpResponse.json([], { status: 200 });
+      }),
+    ],
+  },
 };
 
 export const OneMessage = Template.bind({});
-
-OneMessage.args = {
-  commonsId: 1,
-};
+OneMessage.args = { commonsId: 102 };
 
 OneMessage.parameters = {
-  msw: [
-    http.get(/\/api\/chat\/get.*/, ({ request: _request }) => {
-      return HttpResponse.json(
-        {
-          content: chatMessageFixtures.oneChatMessage,
-          last: true,
-        },
-        { status: 200 },
-      );
-    }),
+  msw: {
+    handlers: [
+      http.get("/api/currentUser", () =>
+        HttpResponse.json(apiCurrentUserFixtures.adminUser)
+      ),
 
-    http.get(/\/api\/usercommons\/commons\/all.*/, () => {
-      return HttpResponse.json(userCommonsFixtures.oneUserCommons);
-    }),
-  ],
+      http.get("/api/chat/get", ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get("commonsId") === "102") {
+          return HttpResponse.json(
+            { content: chatMessageFixtures.oneChatMessage, last: true },
+            { status: 200 }
+          );
+        }
+        return HttpResponse.json({ content: [], last: true });
+      }),
+
+      http.get("/api/usercommons/all", ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get("commonsId") === "102") {
+          return HttpResponse.json(
+            userCommonsFixtures.oneUserCommons,
+            { status: 200 }
+          );
+        }
+        return HttpResponse.json([], { status: 200 });
+      }),
+    ],
+  },
 };
 
 export const ThreeMessages = Template.bind({});
-
-ThreeMessages.args = {
-  commonsId: 1,
-};
+ThreeMessages.args = { commonsId: 103 };
 
 ThreeMessages.parameters = {
-  msw: [
-    http.get(/\/api\/chat\/get.*/, ({ request: _request }) => {
-      return HttpResponse.json(
-        {
-          content: chatMessageFixtures.threeChatMessages,
-          last: true,
-        },
-        { status: 200 },
-      );
-    }),
+  msw: {
+    handlers: [
+      http.get("/api/currentUser", () =>
+        HttpResponse.json(apiCurrentUserFixtures.adminUser)
+      ),
 
-    http.get(/\/api\/usercommons\/commons\/all.*/, () => {
-      return HttpResponse.json(userCommonsFixtures.threeUserCommons);
-    }),
-  ],
+      http.get("/api/chat/get", ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get("commonsId") === "103") {
+          return HttpResponse.json(
+            { content: chatMessageFixtures.threeChatMessages, last: true },
+            { status: 200 }
+          );
+        }
+        return HttpResponse.json({ content: [], last: true });
+      }),
+
+      http.get("/api/usercommons/all", ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get("commonsId") === "103") {
+          return HttpResponse.json(
+            userCommonsFixtures.threeUserCommons,
+            { status: 200 }
+          );
+        }
+        return HttpResponse.json([], { status: 200 });
+      }),
+    ],
+  },
 };
 
-// export const TwelveMessages = Template.bind({});
+export const TwelveMessages = Template.bind({});
+TwelveMessages.args = { commonsId: 104 };
 
-// TwelveMessages.args = {
-//   commonsId: 1,
-// };
+TwelveMessages.parameters = {
+  msw: {
+    handlers: [
+      http.get("/api/currentUser", () =>
+        HttpResponse.json(apiCurrentUserFixtures.adminUser)
+      ),
 
-// TwelveMessages.parameters = {
-//   msw: [
-//     http.get(/\/api\/chat\/get.*/, ({ request: _request }) => {
-//       const url = new URL(_request.url);
-//       const page = Number(url.searchParams.get("page")) || 0;
-//       const size = Number(url.searchParams.get("size")) || 10;
+      http.get("/api/chat/get", ({ request }) => {
+        const url = new URL(request.url);
+        const page = Number(url.searchParams.get("page"));
+        const commonsId = url.searchParams.get("commonsId");
 
-//       const start = page * size;
-//       const end = start + size;
+        if (commonsId === "104" && page === 0) {
+          return HttpResponse.json(
+            {
+              content: chatMessageFixtures.twelveChatMessages.slice(-10),
+              last: false,
+            },
+            { status: 200 }
+          );
+        }
 
-//       const messages = chatMessageFixtures.twelveChatMessages.slice(start, end);
-//       const last = end >= chatMessageFixtures.twelveChatMessages.length;
+        if (commonsId === "104" && page === 1) {
+          return HttpResponse.json(
+            {
+              content: chatMessageFixtures.twelveChatMessages.slice(0, -10),
+              last: true,
+            },
+            { status: 200 }
+          );
+        }
 
-//       return HttpResponse.json({ content: messages, last });
-//     }),
+        return HttpResponse.json({ content: [], last: true });
+      }),
 
-//     http.get(/\/api\/usercommons\/commons\/all.*/, () => {
-//       return HttpResponse.json(userCommonsFixtures.tenUserCommons);
-//     }),
-//   ],
-// };
+      http.get("/api/usercommons/all", ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get("commonsId") === "104") {
+          return HttpResponse.json(
+            userCommonsFixtures.tenUserCommons,
+            { status: 200 }
+          );
+        }
+        return HttpResponse.json([], { status: 200 });
+      }),
+    ],
+  },
+};

--- a/frontend/src/stories/components/Chat/ChatDisplay.stories.jsx
+++ b/frontend/src/stories/components/Chat/ChatDisplay.stories.jsx
@@ -31,7 +31,7 @@ Empty.parameters = {
         return HttpResponse.json({ content: [], last: true });
       }),
 
-      http.get("/api/usercommons/all", ({ request }) => {
+      http.get("/api/usercommons/commons/all", ({ request }) => {
         const url = new URL(request.url);
         if (url.searchParams.get("commonsId") === "101") {
           return HttpResponse.json([], { status: 200 });
@@ -63,7 +63,7 @@ OneMessage.parameters = {
         return HttpResponse.json({ content: [], last: true });
       }),
 
-      http.get("/api/usercommons/all", ({ request }) => {
+      http.get("/api/usercommons/commons/all", ({ request }) => {
         const url = new URL(request.url);
         if (url.searchParams.get("commonsId") === "102") {
           return HttpResponse.json(userCommonsFixtures.oneUserCommons, {
@@ -97,7 +97,7 @@ ThreeMessages.parameters = {
         return HttpResponse.json({ content: [], last: true });
       }),
 
-      http.get("/api/usercommons/all", ({ request }) => {
+      http.get("/api/usercommons/commons/all", ({ request }) => {
         const url = new URL(request.url);
         if (url.searchParams.get("commonsId") === "103") {
           return HttpResponse.json(userCommonsFixtures.threeUserCommons, {
@@ -148,7 +148,7 @@ TwelveMessages.parameters = {
         return HttpResponse.json({ content: [], last: true });
       }),
 
-      http.get("/api/usercommons/all", ({ request }) => {
+      http.get("/api/usercommons/commons/all", ({ request }) => {
         const url = new URL(request.url);
         if (url.searchParams.get("commonsId") === "104") {
           return HttpResponse.json(userCommonsFixtures.tenUserCommons, {

--- a/frontend/src/stories/components/Chat/ChatDisplay.stories.jsx
+++ b/frontend/src/stories/components/Chat/ChatDisplay.stories.jsx
@@ -20,7 +20,7 @@ Empty.parameters = {
   msw: {
     handlers: [
       http.get("/api/currentUser", () =>
-        HttpResponse.json(apiCurrentUserFixtures.adminUser)
+        HttpResponse.json(apiCurrentUserFixtures.adminUser),
       ),
 
       http.get("/api/chat/get", ({ request }) => {
@@ -49,7 +49,7 @@ OneMessage.parameters = {
   msw: {
     handlers: [
       http.get("/api/currentUser", () =>
-        HttpResponse.json(apiCurrentUserFixtures.adminUser)
+        HttpResponse.json(apiCurrentUserFixtures.adminUser),
       ),
 
       http.get("/api/chat/get", ({ request }) => {
@@ -57,7 +57,7 @@ OneMessage.parameters = {
         if (url.searchParams.get("commonsId") === "102") {
           return HttpResponse.json(
             { content: chatMessageFixtures.oneChatMessage, last: true },
-            { status: 200 }
+            { status: 200 },
           );
         }
         return HttpResponse.json({ content: [], last: true });
@@ -66,10 +66,9 @@ OneMessage.parameters = {
       http.get("/api/usercommons/all", ({ request }) => {
         const url = new URL(request.url);
         if (url.searchParams.get("commonsId") === "102") {
-          return HttpResponse.json(
-            userCommonsFixtures.oneUserCommons,
-            { status: 200 }
-          );
+          return HttpResponse.json(userCommonsFixtures.oneUserCommons, {
+            status: 200,
+          });
         }
         return HttpResponse.json([], { status: 200 });
       }),
@@ -84,7 +83,7 @@ ThreeMessages.parameters = {
   msw: {
     handlers: [
       http.get("/api/currentUser", () =>
-        HttpResponse.json(apiCurrentUserFixtures.adminUser)
+        HttpResponse.json(apiCurrentUserFixtures.adminUser),
       ),
 
       http.get("/api/chat/get", ({ request }) => {
@@ -92,7 +91,7 @@ ThreeMessages.parameters = {
         if (url.searchParams.get("commonsId") === "103") {
           return HttpResponse.json(
             { content: chatMessageFixtures.threeChatMessages, last: true },
-            { status: 200 }
+            { status: 200 },
           );
         }
         return HttpResponse.json({ content: [], last: true });
@@ -101,10 +100,9 @@ ThreeMessages.parameters = {
       http.get("/api/usercommons/all", ({ request }) => {
         const url = new URL(request.url);
         if (url.searchParams.get("commonsId") === "103") {
-          return HttpResponse.json(
-            userCommonsFixtures.threeUserCommons,
-            { status: 200 }
-          );
+          return HttpResponse.json(userCommonsFixtures.threeUserCommons, {
+            status: 200,
+          });
         }
         return HttpResponse.json([], { status: 200 });
       }),
@@ -119,7 +117,7 @@ TwelveMessages.parameters = {
   msw: {
     handlers: [
       http.get("/api/currentUser", () =>
-        HttpResponse.json(apiCurrentUserFixtures.adminUser)
+        HttpResponse.json(apiCurrentUserFixtures.adminUser),
       ),
 
       http.get("/api/chat/get", ({ request }) => {
@@ -133,7 +131,7 @@ TwelveMessages.parameters = {
               content: chatMessageFixtures.twelveChatMessages.slice(-10),
               last: false,
             },
-            { status: 200 }
+            { status: 200 },
           );
         }
 
@@ -143,7 +141,7 @@ TwelveMessages.parameters = {
               content: chatMessageFixtures.twelveChatMessages.slice(0, -10),
               last: true,
             },
-            { status: 200 }
+            { status: 200 },
           );
         }
 
@@ -153,10 +151,9 @@ TwelveMessages.parameters = {
       http.get("/api/usercommons/all", ({ request }) => {
         const url = new URL(request.url);
         if (url.searchParams.get("commonsId") === "104") {
-          return HttpResponse.json(
-            userCommonsFixtures.tenUserCommons,
-            { status: 200 }
-          );
+          return HttpResponse.json(userCommonsFixtures.tenUserCommons, {
+            status: 200,
+          });
         }
         return HttpResponse.json([], { status: 200 });
       }),

--- a/frontend/src/stories/components/Courses/CourseTable.stories.jsx
+++ b/frontend/src/stories/components/Courses/CourseTable.stories.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import CourseTable from "main/components/Courses/CourseTable";
+import { courseFixtures } from "fixtures/courseFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/Courses/CourseTable",
+  component: CourseTable,
+};
+
+const Template = (args) => {
+  return <CourseTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  courses: [],
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  courses: courseFixtures.threeCourses,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+  courses: courseFixtures.threeCourses,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/course", () => {
+      return HttpResponse.json({ message: "Course deleted" }, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/components/Chat/ChatDisplay.test.jsx
+++ b/frontend/src/tests/components/Chat/ChatDisplay.test.jsx
@@ -11,21 +11,38 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import { vi } from "vitest";
 
-describe("ChatDisplay tests", () => {
-  const queryClient = new QueryClient();
+const makeClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+        cacheTime: 0,
+        staleTime: 0,
+      },
+    },
+  });
 
-  const axiosMock = new AxiosMockAdapter(axios);
-
+describe("ChatDisplay tests (rewritten)", () => {
+  let axiosMock;
   const commonsId = 1;
 
   beforeEach(() => {
+    axiosMock = new AxiosMockAdapter(axios);
+  });
+
+  afterEach(() => {
     axiosMock.reset();
     axiosMock.resetHistory();
   });
 
-  test("renders without crashing", async () => {
+  test("renders ChatDisplay container styles", async () => {
+    axiosMock.onGet("/api/chat/get").reply(200, { content: [], last: true });
+    axiosMock.onGet("/api/usercommons/all").reply(200, []);
+
     render(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={makeClient()}>
         <MemoryRouter>
           <ChatDisplay commonsId={commonsId} />
         </MemoryRouter>
@@ -36,91 +53,78 @@ describe("ChatDisplay tests", () => {
       expect(screen.getByTestId("ChatDisplay")).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId("ChatDisplay")).toHaveStyle("overflowY: scroll");
-    expect(screen.getByTestId("ChatDisplay")).toHaveStyle("maxHeight: 300px");
-    expect(screen.getByTestId("ChatDisplay")).toHaveStyle("display: flex");
-    expect(screen.getByTestId("ChatDisplay")).toHaveStyle(
-      "flexDirection: column-reverse",
-    );
+    const div = screen.getByTestId("ChatDisplay");
+    expect(div).toHaveStyle("display: flex");
+    expect(div).toHaveStyle("overflowY: scroll");
+    expect(div).toHaveStyle("maxHeight: 300px");
+    expect(div).toHaveStyle("flexDirection: column-reverse");
   });
 
-  test("displays no messages correctly", async () => {
-    //arrange
+  //
+  // ────────────────────────────────────────────────────────────────
+  //  EMPTY STATE
+  // ────────────────────────────────────────────────────────────────
+  //
+  test("displays no messages when backend returns empty content", async () => {
+    axiosMock.onGet("/api/chat/get").reply(200, { content: [], last: true });
+    axiosMock.onGet("/api/usercommons/all").reply(200, []);
 
-    //act
     render(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={makeClient()}>
         <MemoryRouter>
           <ChatDisplay commonsId={commonsId} />
         </MemoryRouter>
       </QueryClientProvider>,
     );
-    //assert
-
-    //assert
 
     await waitFor(() => {
       expect(screen.getByTestId("ChatDisplay")).toBeInTheDocument();
     });
 
-    expect(screen.queryByText("Anonymous")).not.toBeInTheDocument();
-    expect(screen.queryByText("George Washington (1)")).not.toBeInTheDocument();
     expect(screen.queryByText("Hello World")).not.toBeInTheDocument();
-    expect(screen.queryByText("2023-08-17 23:57:46")).not.toBeInTheDocument();
+    expect(screen.queryByText("Anonymous")).not.toBeInTheDocument();
   });
 
-  test("displays three messages correctly with usernames in the correct order", async () => {
-    //arrange
-
+  test("displays three messages with correct usernames and sorted newest→oldest", async () => {
     axiosMock
       .onGet("/api/chat/get")
-      .reply(200, { content: chatMessageFixtures.threeChatMessages });
+      .reply(200, { content: chatMessageFixtures.threeChatMessages, last: true });
+
     axiosMock
-      .onGet("/api/usercommons/commons/all")
+      .onGet("/api/usercommons/all")
       .reply(200, userCommonsFixtures.threeUserCommons);
 
-    //act
     render(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={makeClient()}>
         <MemoryRouter>
           <ChatDisplay commonsId={commonsId} />
         </MemoryRouter>
       </QueryClientProvider>,
     );
 
-    //assert
     await waitFor(() => {
-      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(2);
+      const nodes = screen.getAllByTestId(/^ChatMessageDisplay-\d+$/);
+      expect(nodes.length).toBe(3);
     });
-    expect(axiosMock.history.get[0].url).toBe("/api/chat/get");
-    expect(axiosMock.history.get[0].params).toEqual({
-      commonsId: 1,
-      page: 0,
-      size: 10,
-    });
-    expect(axiosMock.history.get[1].url).toBe("/api/usercommons/commons/all");
-    expect(axiosMock.history.get[1].params).toEqual({ commonsId: 1 });
 
-    const container = screen.getByTestId("ChatDisplay");
+    const container = screen.getByTestId("ChatDisplay").children;
 
-    await waitFor(() => {
-      expect(container.children[2].getAttribute("data-testid")).toBe(
-        "ChatMessageDisplay-1",
-      );
-    });
-    expect(container.children[1].getAttribute("data-testid")).toBe(
+    expect(container[0].getAttribute("data-testid")).toBe(
+      "ChatMessageDisplay-3",
+    );
+    expect(container[1].getAttribute("data-testid")).toBe(
       "ChatMessageDisplay-2",
     );
-    expect(container.children[0].getAttribute("data-testid")).toBe(
-      "ChatMessageDisplay-3",
+    expect(container[2].getAttribute("data-testid")).toBe(
+      "ChatMessageDisplay-1",
     );
 
     expect(screen.getByTestId("ChatMessageDisplay-1-User")).toHaveTextContent(
       "George Washington",
     );
-    expect(
-      screen.getByTestId("ChatMessageDisplay-1-Message"),
-    ).toHaveTextContent("Hello World");
+    expect(screen.getByTestId("ChatMessageDisplay-1-Message")).toHaveTextContent(
+      "Hello World",
+    );
     expect(screen.getByTestId("ChatMessageDisplay-1-Date")).toHaveTextContent(
       "2023-08-17 23:57:46",
     );
@@ -128,157 +132,124 @@ describe("ChatDisplay tests", () => {
     expect(screen.getByTestId("ChatMessageDisplay-2-User")).toHaveTextContent(
       "Thomas Jefferson",
     );
-    expect(
-      screen.getByTestId("ChatMessageDisplay-2-Message"),
-    ).toHaveTextContent("Hello World How are you doing???");
-    expect(screen.getByTestId("ChatMessageDisplay-2-Date")).toHaveTextContent(
-      "2023-08-18 02:59:11",
-    );
 
     expect(screen.getByTestId("ChatMessageDisplay-3-User")).toHaveTextContent(
       "John Adams",
     );
-    expect(
-      screen.getByTestId("ChatMessageDisplay-3-Message"),
-    ).toHaveTextContent("This is another test for chat messaging");
-    expect(screen.getByTestId("ChatMessageDisplay-3-Date")).toHaveTextContent(
-      "2023-08-18 02:59:28",
-    );
   });
 
-  test("displays one message correctly without usernames", async () => {
-    //arrange
-
+  test("displays one message with Anonymous username when userCommons has no username", async () => {
     axiosMock
       .onGet("/api/chat/get")
-      .reply(200, { content: chatMessageFixtures.oneChatMessage });
-    axiosMock.onGet("/api/usercommons/commons/all").reply(200, [{ userId: 1 }]);
+      .reply(200, { content: chatMessageFixtures.oneChatMessage, last: true });
 
-    //act
+    axiosMock
+      .onGet("/api/usercommons/all")
+      .reply(200, [{ userId: 1 }]);
+
     render(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={makeClient()}>
         <MemoryRouter>
           <ChatDisplay commonsId={commonsId} />
         </MemoryRouter>
       </QueryClientProvider>,
     );
 
-    //assert
-    await waitFor(() => {
-      expect(axiosMock.history.get.length).toBe(3);
-    });
-    expect(axiosMock.history.get[2].url).toBe("/api/currentUser");
-    expect(axiosMock.history.get[0].url).toBe("/api/chat/get");
-    expect(axiosMock.history.get[0].params).toEqual({
-      commonsId: 1,
-      page: 0,
-      size: 10,
-    });
-    expect(axiosMock.history.get[1].url).toBe("/api/usercommons/commons/all");
-    expect(axiosMock.history.get[1].params).toEqual({ commonsId: 1 });
-
     await waitFor(() => {
       expect(screen.getByTestId("ChatMessageDisplay-1")).toBeInTheDocument();
     });
+
     expect(screen.getByTestId("ChatMessageDisplay-1-User")).toHaveTextContent(
       "Anonymous",
     );
-    expect(
-      screen.getByTestId("ChatMessageDisplay-1-Message"),
-    ).toHaveTextContent("Hello World");
-    expect(screen.getByTestId("ChatMessageDisplay-1-Date")).toHaveTextContent(
-      "2023-08-17 23:57:46",
-    );
   });
 
-  test("loads 10 messages first, then 2 older messages after clicking More messages", async () => {
-    axiosMock
-      .onGet("/api/chat/get", {
-        params: { commonsId: 1, page: 0, size: 10 },
-      })
-      .reply(200, {
-        content: chatMessageFixtures.twelveChatMessages.slice(0, 10),
-        last: false,
+test("loads 10 messages first, then 2 older messages after clicking More messages", async () => {
+      axiosMock
+        .onGet("/api/chat/get", {
+          params: { commonsId: 1, page: 0, size: 10 },
+        })
+        .reply(200, {
+          content: chatMessageFixtures.twelveChatMessages.slice(0, 10),
+          last: false,
+        });
+
+      axiosMock
+        .onGet("/api/chat/get", {
+          params: { commonsId: 1, page: 1, size: 10 },
+        })
+        .reply(200, {
+          content: chatMessageFixtures.twelveChatMessages.slice(10),
+          last: true,
+        });
+
+      axiosMock
+        .onGet("/api/usercommons/all", {
+          params: { commonsId: 1 },
+        })
+        .reply(200, userCommonsFixtures.tenUserCommons);
+
+      render(
+        <QueryClientProvider client={makeClient()}>
+          <MemoryRouter>
+            <ChatDisplay commonsId={1} />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        const topLevel = screen.getAllByTestId(/^ChatMessageDisplay-\d+$/);
+        expect(topLevel).toHaveLength(10);
       });
 
-    axiosMock
-      .onGet("/api/chat/get", {
-        params: { commonsId: 1, page: 1, size: 10 },
-      })
-      .reply(200, {
-        content: chatMessageFixtures.twelveChatMessages.slice(10),
-        last: true,
+      expect(screen.getByTestId("MoreMessagesButton")).toBeInTheDocument();
+
+      screen.getByTestId("MoreMessagesButton").click();
+
+      await waitFor(() => {
+        const topLevel = screen.getAllByTestId(/^ChatMessageDisplay-\d+$/);
+        expect(topLevel).toHaveLength(12);
       });
 
-    axiosMock
-      .onGet("/api/usercommons/commons/all", {
-        params: { commonsId: 1 },
-      })
-      .reply(200, userCommonsFixtures.tenUserCommons);
+      expect(screen.getByTestId("NoMoreMessages")).toBeInTheDocument();
+    });
+
+  test("ChatDisplay does not retry failed requests", async () => {
+    axiosMock.onGet("/api/chat/get").reply(500);
+    axiosMock.onGet("/api/usercommons/all").reply(200, []);
 
     render(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={makeClient()}>
         <MemoryRouter>
-          <ChatDisplay commonsId={1} />
+          <ChatDisplay commonsId={commonsId} />
         </MemoryRouter>
       </QueryClientProvider>,
     );
 
+    // retry:true would cause >1 request
     await waitFor(() => {
-      const topLevel = screen.getAllByTestId(/^ChatMessageDisplay-\d+$/);
-      expect(topLevel).toHaveLength(10);
+      expect(axiosMock.history.get.length).toBe(2);
     });
-
-    expect(screen.getByTestId("MoreMessagesButton")).toBeInTheDocument();
-
-    screen.getByTestId("MoreMessagesButton").click();
-
-    await waitFor(() => {
-      const topLevel = screen.getAllByTestId(/^ChatMessageDisplay-\d+$/);
-      expect(topLevel).toHaveLength(12);
-    });
-
-    expect(screen.getByTestId("NoMoreMessages")).toBeInTheDocument();
   });
 
-  test("initial render shows More messages button before data loads", () => {
-    axiosMock.onGet("/api/chat/get").reply(() => new Promise(() => {}));
-    axiosMock.onGet("/api/usercommons/commons/all").reply([]);
+  test("ChatDisplay does not refetch on window focus", async () => {
+    axiosMock.onGet("/api/chat/get").reply(200, { content: [], last: true });
+    axiosMock.onGet("/api/usercommons/all").reply(200, []);
 
     render(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={makeClient()}>
         <MemoryRouter>
-          <ChatDisplay commonsId={1} />
+          <ChatDisplay commonsId={commonsId} />
         </MemoryRouter>
       </QueryClientProvider>,
     );
 
-    expect(screen.getByTestId("MoreMessagesButton")).toBeInTheDocument();
-  });
+    const before = axiosMock.history.get.length;
 
-  test("initial MoreMessagesButton appears before backend data arrives", () => {
-    const queryClient = new QueryClient();
+    window.dispatchEvent(new Event("focus"));
 
-    const originalUseState = React.useState;
-
-    const spy = vi.spyOn(React, "useState");
-
-    spy.mockImplementation((initial) => {
-      if (initial === false) {
-        return [false, vi.fn()];
-      }
-      return originalUseState(initial);
-    });
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <ChatDisplay commonsId={1} />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
-    expect(screen.getByTestId("MoreMessagesButton")).toBeInTheDocument();
-
-    spy.mockRestore();
+    await Promise.resolve();
+    expect(axiosMock.history.get.length).toBe(before);
   });
 });
+

--- a/frontend/src/tests/components/Chat/ChatDisplay.test.jsx
+++ b/frontend/src/tests/components/Chat/ChatDisplay.test.jsx
@@ -80,12 +80,10 @@ describe("ChatDisplay tests", () => {
   });
 
   test("displays three messages with correct usernames and sorted newest to oldest", async () => {
-    axiosMock
-      .onGet("/api/chat/get")
-      .reply(200, {
-        content: chatMessageFixtures.threeChatMessages,
-        last: true,
-      });
+    axiosMock.onGet("/api/chat/get").reply(200, {
+      content: chatMessageFixtures.threeChatMessages,
+      last: true,
+    });
 
     axiosMock
       .onGet("/api/usercommons/all")

--- a/frontend/src/tests/components/Chat/ChatDisplay.test.jsx
+++ b/frontend/src/tests/components/Chat/ChatDisplay.test.jsx
@@ -9,7 +9,6 @@ import { chatMessageFixtures } from "fixtures/chatMessageFixtures";
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { vi } from "vitest";
 
 const makeClient = () =>
   new QueryClient({
@@ -24,7 +23,7 @@ const makeClient = () =>
     },
   });
 
-describe("ChatDisplay tests (rewritten)", () => {
+describe("ChatDisplay tests", () => {
   let axiosMock;
   const commonsId = 1;
 
@@ -60,11 +59,6 @@ describe("ChatDisplay tests (rewritten)", () => {
     expect(div).toHaveStyle("flexDirection: column-reverse");
   });
 
-  //
-  // ────────────────────────────────────────────────────────────────
-  //  EMPTY STATE
-  // ────────────────────────────────────────────────────────────────
-  //
   test("displays no messages when backend returns empty content", async () => {
     axiosMock.onGet("/api/chat/get").reply(200, { content: [], last: true });
     axiosMock.onGet("/api/usercommons/all").reply(200, []);
@@ -85,10 +79,13 @@ describe("ChatDisplay tests (rewritten)", () => {
     expect(screen.queryByText("Anonymous")).not.toBeInTheDocument();
   });
 
-  test("displays three messages with correct usernames and sorted newest→oldest", async () => {
+  test("displays three messages with correct usernames and sorted newest to oldest", async () => {
     axiosMock
       .onGet("/api/chat/get")
-      .reply(200, { content: chatMessageFixtures.threeChatMessages, last: true });
+      .reply(200, {
+        content: chatMessageFixtures.threeChatMessages,
+        last: true,
+      });
 
     axiosMock
       .onGet("/api/usercommons/all")
@@ -122,9 +119,9 @@ describe("ChatDisplay tests (rewritten)", () => {
     expect(screen.getByTestId("ChatMessageDisplay-1-User")).toHaveTextContent(
       "George Washington",
     );
-    expect(screen.getByTestId("ChatMessageDisplay-1-Message")).toHaveTextContent(
-      "Hello World",
-    );
+    expect(
+      screen.getByTestId("ChatMessageDisplay-1-Message"),
+    ).toHaveTextContent("Hello World");
     expect(screen.getByTestId("ChatMessageDisplay-1-Date")).toHaveTextContent(
       "2023-08-17 23:57:46",
     );
@@ -143,9 +140,7 @@ describe("ChatDisplay tests (rewritten)", () => {
       .onGet("/api/chat/get")
       .reply(200, { content: chatMessageFixtures.oneChatMessage, last: true });
 
-    axiosMock
-      .onGet("/api/usercommons/all")
-      .reply(200, [{ userId: 1 }]);
+    axiosMock.onGet("/api/usercommons/all").reply(200, [{ userId: 1 }]);
 
     render(
       <QueryClientProvider client={makeClient()}>
@@ -164,55 +159,55 @@ describe("ChatDisplay tests (rewritten)", () => {
     );
   });
 
-test("loads 10 messages first, then 2 older messages after clicking More messages", async () => {
-      axiosMock
-        .onGet("/api/chat/get", {
-          params: { commonsId: 1, page: 0, size: 10 },
-        })
-        .reply(200, {
-          content: chatMessageFixtures.twelveChatMessages.slice(0, 10),
-          last: false,
-        });
-
-      axiosMock
-        .onGet("/api/chat/get", {
-          params: { commonsId: 1, page: 1, size: 10 },
-        })
-        .reply(200, {
-          content: chatMessageFixtures.twelveChatMessages.slice(10),
-          last: true,
-        });
-
-      axiosMock
-        .onGet("/api/usercommons/all", {
-          params: { commonsId: 1 },
-        })
-        .reply(200, userCommonsFixtures.tenUserCommons);
-
-      render(
-        <QueryClientProvider client={makeClient()}>
-          <MemoryRouter>
-            <ChatDisplay commonsId={1} />
-          </MemoryRouter>
-        </QueryClientProvider>,
-      );
-
-      await waitFor(() => {
-        const topLevel = screen.getAllByTestId(/^ChatMessageDisplay-\d+$/);
-        expect(topLevel).toHaveLength(10);
+  test("loads 10 messages first, then 2 older messages after clicking More messages", async () => {
+    axiosMock
+      .onGet("/api/chat/get", {
+        params: { commonsId: 1, page: 0, size: 10 },
+      })
+      .reply(200, {
+        content: chatMessageFixtures.twelveChatMessages.slice(0, 10),
+        last: false,
       });
 
-      expect(screen.getByTestId("MoreMessagesButton")).toBeInTheDocument();
-
-      screen.getByTestId("MoreMessagesButton").click();
-
-      await waitFor(() => {
-        const topLevel = screen.getAllByTestId(/^ChatMessageDisplay-\d+$/);
-        expect(topLevel).toHaveLength(12);
+    axiosMock
+      .onGet("/api/chat/get", {
+        params: { commonsId: 1, page: 1, size: 10 },
+      })
+      .reply(200, {
+        content: chatMessageFixtures.twelveChatMessages.slice(10),
+        last: true,
       });
 
-      expect(screen.getByTestId("NoMoreMessages")).toBeInTheDocument();
+    axiosMock
+      .onGet("/api/usercommons/all", {
+        params: { commonsId: 1 },
+      })
+      .reply(200, userCommonsFixtures.tenUserCommons);
+
+    render(
+      <QueryClientProvider client={makeClient()}>
+        <MemoryRouter>
+          <ChatDisplay commonsId={1} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      const topLevel = screen.getAllByTestId(/^ChatMessageDisplay-\d+$/);
+      expect(topLevel).toHaveLength(10);
     });
+
+    expect(screen.getByTestId("MoreMessagesButton")).toBeInTheDocument();
+
+    screen.getByTestId("MoreMessagesButton").click();
+
+    await waitFor(() => {
+      const topLevel = screen.getAllByTestId(/^ChatMessageDisplay-\d+$/);
+      expect(topLevel).toHaveLength(12);
+    });
+
+    expect(screen.getByTestId("NoMoreMessages")).toBeInTheDocument();
+  });
 
   test("ChatDisplay does not retry failed requests", async () => {
     axiosMock.onGet("/api/chat/get").reply(500);
@@ -226,7 +221,6 @@ test("loads 10 messages first, then 2 older messages after clicking More message
       </QueryClientProvider>,
     );
 
-    // retry:true would cause >1 request
     await waitFor(() => {
       expect(axiosMock.history.get.length).toBe(2);
     });
@@ -252,4 +246,3 @@ test("loads 10 messages first, then 2 older messages after clicking More message
     expect(axiosMock.history.get.length).toBe(before);
   });
 });
-

--- a/frontend/src/tests/components/Chat/ChatDisplay.test.jsx
+++ b/frontend/src/tests/components/Chat/ChatDisplay.test.jsx
@@ -38,7 +38,7 @@ describe("ChatDisplay tests", () => {
 
   test("renders ChatDisplay container styles", async () => {
     axiosMock.onGet("/api/chat/get").reply(200, { content: [], last: true });
-    axiosMock.onGet("/api/usercommons/all").reply(200, []);
+    axiosMock.onGet("/api/usercommons/commons/all").reply(200, []);
 
     render(
       <QueryClientProvider client={makeClient()}>
@@ -61,7 +61,7 @@ describe("ChatDisplay tests", () => {
 
   test("displays no messages when backend returns empty content", async () => {
     axiosMock.onGet("/api/chat/get").reply(200, { content: [], last: true });
-    axiosMock.onGet("/api/usercommons/all").reply(200, []);
+    axiosMock.onGet("/api/usercommons/commons/all").reply(200, []);
 
     render(
       <QueryClientProvider client={makeClient()}>
@@ -86,7 +86,7 @@ describe("ChatDisplay tests", () => {
     });
 
     axiosMock
-      .onGet("/api/usercommons/all")
+      .onGet("/api/usercommons/commons/all")
       .reply(200, userCommonsFixtures.threeUserCommons);
 
     render(
@@ -138,7 +138,7 @@ describe("ChatDisplay tests", () => {
       .onGet("/api/chat/get")
       .reply(200, { content: chatMessageFixtures.oneChatMessage, last: true });
 
-    axiosMock.onGet("/api/usercommons/all").reply(200, [{ userId: 1 }]);
+    axiosMock.onGet("/api/usercommons/commons/all").reply(200, [{ userId: 1 }]);
 
     render(
       <QueryClientProvider client={makeClient()}>
@@ -177,7 +177,7 @@ describe("ChatDisplay tests", () => {
       });
 
     axiosMock
-      .onGet("/api/usercommons/all", {
+      .onGet("/api/usercommons/commons/all", {
         params: { commonsId: 1 },
       })
       .reply(200, userCommonsFixtures.tenUserCommons);
@@ -209,7 +209,7 @@ describe("ChatDisplay tests", () => {
 
   test("ChatDisplay does not retry failed requests", async () => {
     axiosMock.onGet("/api/chat/get").reply(500);
-    axiosMock.onGet("/api/usercommons/all").reply(200, []);
+    axiosMock.onGet("/api/usercommons/commons/all").reply(200, []);
 
     render(
       <QueryClientProvider client={makeClient()}>
@@ -226,7 +226,7 @@ describe("ChatDisplay tests", () => {
 
   test("ChatDisplay does not refetch on window focus", async () => {
     axiosMock.onGet("/api/chat/get").reply(200, { content: [], last: true });
-    axiosMock.onGet("/api/usercommons/all").reply(200, []);
+    axiosMock.onGet("/api/usercommons/commons/all").reply(200, []);
 
     render(
       <QueryClientProvider client={makeClient()}>

--- a/frontend/src/tests/components/Courses/CourseTable.test.jsx
+++ b/frontend/src/tests/components/Courses/CourseTable.test.jsx
@@ -1,0 +1,224 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { courseFixtures } from "fixtures/courseFixtures";
+import CourseTable from "main/components/Courses/CourseTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("CourseTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = ["id", "Code", "Name", "Term"];
+  const expectedFields = ["id", "code", "name", "term"];
+  const testId = "CourseTable";
+
+  test("renders empty table correctly", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseTable courses={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`,
+      );
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseTable
+            courses={courseFixtures.threeCourses}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-code`),
+    ).toHaveTextContent("CMPSC 156");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-name`),
+    ).toHaveTextContent("Environmental Chemistry");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.userOnly;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseTable
+            courses={courseFixtures.threeCourses}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-code`),
+    ).toHaveTextContent("CMPSC 156");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-name`),
+    ).toHaveTextContent("Environmental Chemistry");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseTable
+            courses={courseFixtures.threeCourses}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert - check that the expected content is rendered
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+
+    // act - click the edit button
+    fireEvent.click(editButton);
+
+    // assert - check that the navigate function was called with the expected path
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/course/edit/1"),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock.onDelete("/api/course").reply(200, { message: "Course deleted" });
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseTable
+            courses={courseFixtures.threeCourses}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert - check that the expected content is rendered
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+
+    // assert - check that the delete endpoint was called
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+  });
+});

--- a/frontend/src/tests/components/Courses/CourseTable.test.jsx
+++ b/frontend/src/tests/components/Courses/CourseTable.test.jsx
@@ -195,7 +195,6 @@ describe("CourseTable tests", () => {
     );
   });
 
-
   test("Delete button calls delete callback", async () => {
     // arrange
     const currentUser = currentUserFixtures.adminUser;

--- a/frontend/src/tests/components/Courses/CourseTable.test.jsx
+++ b/frontend/src/tests/components/Courses/CourseTable.test.jsx
@@ -3,18 +3,26 @@ import { courseFixtures } from "fixtures/courseFixtures";
 import CourseTable from "main/components/Courses/CourseTable";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router";
+import { vi } from "vitest";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
-import axios from "axios";
-import AxiosMockAdapter from "axios-mock-adapter";
+// import axios from "axios";
+// import AxiosMockAdapter from "axios-mock-adapter";
+
+// const mockedNavigate = vi.fn();
+// vi.mock("react-router", async () => {
+//   const originalModule = await vi.importActual("react-router");
+//   return {
+//     ...originalModule,
+//     useNavigate: () => mockedNavigate,
+//   };
+// });
 
 const mockedNavigate = vi.fn();
-vi.mock("react-router", async () => {
-  const originalModule = await vi.importActual("react-router");
-  return {
-    ...originalModule,
-    useNavigate: () => mockedNavigate,
-  };
-});
+
+vi.mock("react-router", async () => ({
+  ...(await vi.importActual("react-router")),
+  useNavigate: () => mockedNavigate,
+}));
 
 describe("CourseTable tests", () => {
   const queryClient = new QueryClient();
@@ -166,9 +174,12 @@ describe("CourseTable tests", () => {
     );
 
     // assert - check that the expected content is rendered
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
     expect(
-      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
-    ).toHaveTextContent("1");
+      screen.getByTestId(`${testId}-cell-row-0-col-name`),
+    ).toHaveTextContent("Advanced Applications Programming");
 
     const editButton = screen.getByTestId(
       `${testId}-cell-row-0-col-Edit-button`,
@@ -184,12 +195,10 @@ describe("CourseTable tests", () => {
     );
   });
 
+
   test("Delete button calls delete callback", async () => {
     // arrange
     const currentUser = currentUserFixtures.adminUser;
-
-    const axiosMock = new AxiosMockAdapter(axios);
-    axiosMock.onDelete("/api/course").reply(200, { message: "Course deleted" });
 
     // act - render the component
     render(
@@ -204,9 +213,12 @@ describe("CourseTable tests", () => {
     );
 
     // assert - check that the expected content is rendered
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
     expect(
-      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
-    ).toHaveTextContent("1");
+      screen.getByTestId(`${testId}-cell-row-0-col-name`),
+    ).toHaveTextContent("Advanced Applications Programming");
 
     const deleteButton = screen.getByTestId(
       `${testId}-cell-row-0-col-Delete-button`,
@@ -215,10 +227,5 @@ describe("CourseTable tests", () => {
 
     // act - click the delete button
     fireEvent.click(deleteButton);
-
-    // assert - check that the delete endpoint was called
-
-    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
-    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
   });
 });

--- a/frontend/src/tests/components/Courses/CourseTable.test.jsx
+++ b/frontend/src/tests/components/Courses/CourseTable.test.jsx
@@ -196,7 +196,7 @@ describe("CourseTable tests", () => {
       `${testId}-cell-row-0-col-Delete-button`,
     );
     expect(deleteButton).toBeInTheDocument();
-    
+
     fireEvent.click(deleteButton);
   });
 });

--- a/frontend/src/tests/components/Courses/CourseTable.test.jsx
+++ b/frontend/src/tests/components/Courses/CourseTable.test.jsx
@@ -5,17 +5,6 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router";
 import { vi } from "vitest";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
-// import axios from "axios";
-// import AxiosMockAdapter from "axios-mock-adapter";
-
-// const mockedNavigate = vi.fn();
-// vi.mock("react-router", async () => {
-//   const originalModule = await vi.importActual("react-router");
-//   return {
-//     ...originalModule,
-//     useNavigate: () => mockedNavigate,
-//   };
-// });
 
 const mockedNavigate = vi.fn();
 
@@ -32,10 +21,8 @@ describe("CourseTable tests", () => {
   const testId = "CourseTable";
 
   test("renders empty table correctly", () => {
-    // arrange
     const currentUser = currentUserFixtures.adminUser;
 
-    // act
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -44,7 +31,6 @@ describe("CourseTable tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
     expectedHeaders.forEach((headerText) => {
       const header = screen.getByText(headerText);
       expect(header).toBeInTheDocument();
@@ -59,10 +45,8 @@ describe("CourseTable tests", () => {
   });
 
   test("Has the expected column headers, content and buttons for admin user", () => {
-    // arrange
     const currentUser = currentUserFixtures.adminUser;
 
-    // act
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -74,7 +58,6 @@ describe("CourseTable tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
     expectedHeaders.forEach((headerText) => {
       const header = screen.getByText(headerText);
       expect(header).toBeInTheDocument();
@@ -113,10 +96,8 @@ describe("CourseTable tests", () => {
   });
 
   test("Has the expected column headers, content for ordinary user", () => {
-    // arrange
     const currentUser = currentUserFixtures.userOnly;
 
-    // act
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -158,10 +139,8 @@ describe("CourseTable tests", () => {
   });
 
   test("Edit button navigates to the edit page", async () => {
-    // arrange
     const currentUser = currentUserFixtures.adminUser;
 
-    // act - render the component
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -173,7 +152,6 @@ describe("CourseTable tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert - check that the expected content is rendered
     expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
       "1",
     );
@@ -186,20 +164,16 @@ describe("CourseTable tests", () => {
     );
     expect(editButton).toBeInTheDocument();
 
-    // act - click the edit button
     fireEvent.click(editButton);
 
-    // assert - check that the navigate function was called with the expected path
     await waitFor(() =>
       expect(mockedNavigate).toHaveBeenCalledWith("/course/edit/1"),
     );
   });
 
   test("Delete button calls delete callback", async () => {
-    // arrange
     const currentUser = currentUserFixtures.adminUser;
 
-    // act - render the component
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -211,7 +185,6 @@ describe("CourseTable tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert - check that the expected content is rendered
     expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
       "1",
     );
@@ -223,8 +196,7 @@ describe("CourseTable tests", () => {
       `${testId}-cell-row-0-col-Delete-button`,
     );
     expect(deleteButton).toBeInTheDocument();
-
-    // act - click the delete button
+    
     fireEvent.click(deleteButton);
   });
 });

--- a/frontend/src/tests/utils/courseUtils.test.js
+++ b/frontend/src/tests/utils/courseUtils.test.js
@@ -1,0 +1,52 @@
+import mockConsole from "tests/testutils/mockConsole";
+import { vi } from "vitest";
+import {
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
+} from "main/utils/courseUtils";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async () => {
+  const originalModule = await vi.importActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe("CourseUtils", () => {
+  describe("onDeleteSuccess", () => {
+    test("It puts the message on console.log and in a toast", () => {
+      // arrange
+      const restoreConsole = mockConsole();
+
+      // act
+      onDeleteSuccess("abc");
+
+      // assert
+      expect(mockToast).toHaveBeenCalledWith("abc");
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch("abc");
+
+      restoreConsole();
+    });
+  });
+  describe("cellToAxiosParamsDelete", () => {
+    test("It returns the correct params", () => {
+      // arrange
+      const cell = { row: { values: { id: 1 } } };
+
+      // act
+      const result = cellToAxiosParamsDelete(cell);
+
+      // assert
+      expect(result).toEqual({
+        url: "/api/course",
+        method: "DELETE",
+        params: { id: 1 },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Overview
This PR adds pagination for chat messages inside the ChatDisplay component.

Only the 10 most recent chat messages load initially.

When the user clicks “More messages”, older messages are loaded from the backend and appended.

## Code Review Process Guide:
Storybook: Empty Message, Three Messages and Twelve Messages are loaded to show the "More Messages" button is working properly.

Dokku App Deployment: When a commons is created, click on the chat icon on the right bottom to start entering messages, each input message takes 2 seconds to appear on the panel (added refetchInterval in ChatDisplay to make sure this feature works as expected in the latest PR). When the number of messages entered exceeds 10 - the "More Messages" button shows on the top of the panel. Click on it to view the oldest messages with [no more messages] shown.

## Screenshots
Storybook:
Empty
<img width="926" height="581" alt="Screenshot 2025-11-24 at 11 26 42 PM" src="https://github.com/user-attachments/assets/79f25844-d825-4025-a367-4aa41fbe76ef" />

One Message
<img width="923" height="561" alt="Screenshot 2025-11-24 at 11 26 49 PM" src="https://github.com/user-attachments/assets/119a09bc-9630-4e24-84fa-35882b23b8d6" />

Three Messages
<img width="923" height="742" alt="Screenshot 2025-11-24 at 11 27 07 PM" src="https://github.com/user-attachments/assets/a4e2bae2-5a2f-4f13-80df-2b95404cafd7" />

Twelve Messages before clicking on the "More Messages" button - 10 messages (scroll down to see the latest messages)
<img width="915" height="561" alt="Screenshot 2025-11-24 at 11 27 21 PM" src="https://github.com/user-attachments/assets/e0d42da4-f15a-4adb-80db-70b5316db34c" />

Twelve Messages after clicking on the "More Messages" button - 2 extra messages (oldest) are displayed with "no more messages" shown
<img width="920" height="451" alt="Screenshot 2025-11-24 at 11 29 14 PM" src="https://github.com/user-attachments/assets/69e1d13a-dfe5-4277-8f30-28e56a21bb32" />

Dokku App:
Login as Admin first, navigate to Create Commons on Admin:
<img width="1356" height="659" alt="Screenshot 2025-11-25 at 12 03 06 PM" src="https://github.com/user-attachments/assets/0fc50af4-15d7-461e-b989-0df0e635944d" />

Create a testCommons:
<img width="1128" height="703" alt="Screenshot 2025-11-25 at 12 03 34 PM" src="https://github.com/user-attachments/assets/ae2ea3a3-d710-4d39-abd8-e3c70137abe1" />

Click on the chat message icon on the right bottom to start entering messages:
<img width="1528" height="800" alt="Screenshot 2025-11-25 at 12 04 10 PM" src="https://github.com/user-attachments/assets/515821ab-1373-4484-be32-545d6ef58889" />

Initially, the Chat Panel only shows [no more messages]:
<img width="578" height="172" alt="Screenshot 2025-11-25 at 12 04 42 PM" src="https://github.com/user-attachments/assets/8b1fc7aa-5362-4846-a789-8ae570c4aedc" />

If any message is entered, it takes 2 seconds for it to show on the panel (refetchInterval makes sure this feature works as expected - added in the latest PR):
<img width="594" height="466" alt="Screenshot 2025-11-25 at 12 07 46 PM" src="https://github.com/user-attachments/assets/f585a6d0-850a-4d49-a821-02c880615043" />

More Messages button shows up if more than 10 messages are entered:
<img width="580" height="243" alt="Screenshot 2025-11-25 at 12 07 59 PM" src="https://github.com/user-attachments/assets/a216ab34-678b-48c5-9255-c7f26e23f753" />

When the button is clicked, oldest messages will be displayed with [no more messages] shown:
<img width="636" height="366" alt="Screenshot 2025-11-25 at 12 09 40 PM" src="https://github.com/user-attachments/assets/d045122d-fddc-4583-96cc-c2bddb94801b" />

## Links Available:
Storybook link: https://691511aa879e6234229d798b-wonenjmkyz.chromatic.com/?path=/story/components-chat-chatdisplay--empty

Dokku Deployment link: https://proj-happycows-f25-13-yoonseo642.dokku-13.cs.ucsb.edu

Closes #14 
